### PR TITLE
rm placeholder rule

### DIFF
--- a/projects/file_formats/text-rep.md
+++ b/projects/file_formats/text-rep.md
@@ -34,12 +34,6 @@ last modified: 2021-06-17
 It is recommended to use the suffix `.ort` (**o**rso **r**eflectivity **t**extfile) for
 reflectivity files following this standard.
 
-### placeholders
-
-If there is no entry available for a keyword, the default value for both, string and numbers is
-the string `null` 
-
-
 ### language
 
 In line with CANSAS and NEXUS, we use American English for the key words. 


### PR DESCRIPTION
»If there is no entry available for a keyword, the default value for both, string and numbers is the string null« --- The exact meaning of this is unclear to me. Anyway, I see no case for such a rule:

  - If a keyword-value pair is _required_, then the file creator must provide a meaningful value; otherwise the file will not be conform to the standard.
  - If a keyword-value pair is _optional_, then it should rather be omitted than made up with a meaningless default value.